### PR TITLE
A little addition to readme that makes life easier

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,16 +102,22 @@ RxJsoup.connect(
 
 In your module [![Download](https://api.bintray.com/packages/florent37/maven/retrojsoup-compiler/images/download.svg)](https://bintray.com/florent37/maven/retrojsoup-compiler/_latestVersion)
 ```groovy
-compile 'com.github.florent37:retrojsoup:1.0.4'
-compile 'com.github.florent37:rxjsoup:1.0.4'
-annotationProcessor 'com.github.florent37:retrojsoup-compiler:1.0.4'
+dependencies {
+  compile 'com.github.florent37:retrojsoup:1.0.4'
+  compile 'com.github.florent37:rxjsoup:1.0.4'
+  annotationProcessor 'com.github.florent37:retrojsoup-compiler:1.0.4'
 
-//don't forget to include jsoup & rxjava
-compile 'org.jsoup:jsoup:1.10.2'
-compile 'io.reactivex.rxjava2:rxjava:2.0.7'
+  //don't forget to include jsoup & rxjava
+  compile 'org.jsoup:jsoup:1.10.2'
+  compile 'io.reactivex.rxjava2:rxjava:2.0.7'
 
-//optionaly
-compile 'com.squareup.okhttp3:okhttp:3.6.0'
+  //optionaly
+  compile 'com.squareup.okhttp3:okhttp:3.6.0'
+}
+
+repositories {
+  jcenter()
+}
 ```
 # Credits
 


### PR DESCRIPTION
It would be helpful to understand that `jcenter` repo should be used to fetch these dependencies.